### PR TITLE
Add "1/0" entry for HVAC_MODE_SETS

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -72,6 +72,10 @@ HVAC_MODE_SETS = {
     "True/False": {
         HVAC_MODE_HEAT: True,
     },
+    "1/0": {
+        HVAC_MODE_HEAT: "1",
+        HVAC_MODE_AUTO: "0",
+    },
 }
 HVAC_ACTION_SETS = {
     "True/False": {


### PR DESCRIPTION
BHT-002 thermostat DP 4 set the heating mode (auto or manual). The accepted values are strings "0" for auto mode and "1" for manual mode.
This commit add an entry "1/0" to support this behaviour.
Solve issue #799
![Capture d’écran du 2022-06-28 08-12-37](https://user-images.githubusercontent.com/10390464/176112884-3d4597ca-f124-4e4c-b931-5ba4e1773f26.png)
